### PR TITLE
Fix gateway ports

### DIFF
--- a/reactive-jhipster/docker-compose/docker-compose.yml
+++ b/reactive-jhipster/docker-compose/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - JHIPSTER_SLEEP=30
       - JHIPSTER_REGISTRY_PASSWORD=admin
     ports:
-      - "8080:8080:8080"
+      - "8080:8080"
   gateway-postgresql:
     image: postgres:13.2
     environment:


### PR DESCRIPTION
Looks like the `docker-compose.yml` had a typo. I've cleaned up the `ports` for the `gateway` service.

Fixes https://github.com/docker/compose-cli/issues/1652

Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>