### PR TITLE
fix compose file

### DIFF
--- a/reactive-jhipster/docker-compose/docker-compose.yml
+++ b/reactive-jhipster/docker-compose/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   gateway:
     image: gateway
@@ -16,7 +15,7 @@ services:
       - JHIPSTER_SLEEP=30
       - JHIPSTER_REGISTRY_PASSWORD=admin
     ports:
-      - "8080:8080:8080"
+      - "8080:8080"
   gateway-postgresql:
     image: postgres:13.2
     environment:


### PR DESCRIPTION
1. fixed port binding to use invalid syntax `8080:8080:8080` which docker-compose silently ignores (?)
2. removed version header, which isn't required since 1.28 - see compose-spec.io

close docker/compose-cli#1652